### PR TITLE
Fix regex erroneously not filtering half of ASCII

### DIFF
--- a/siPhon
+++ b/siPhon
@@ -124,7 +124,7 @@ def tsanitize(st):
 
 #Clean up filenames
 def fsanitize(st):
-	st = re.sub('[^a-zA-Z0-9 -_.,]','',st)
+	st = re.sub('[^a-zA-Z0-9 \-_.,]','',st)
 	st = re.sub('\s+$','',st)
 	st = re.sub('^\s+','',st)
 	return st


### PR DESCRIPTION
regex statement erroneously matches space through to underscore (0x20 through 0x5F), which includes half of (non-extended) ASCII, and thus all of the characters that are considered illegal for a Windows filename (aside from the pipe symbol)