### PR TITLE
Fixed regexes throwing SyntaxWarnings and added conda environment file

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,8 @@
+name: siphon
+channels:
+- conda-forge
+dependencies:
+- python
+- mutagen
+- tqdm
+- python-magic

--- a/siPhon
+++ b/siPhon
@@ -114,19 +114,19 @@ def rmdb():
 #Clean up tags
 def tsanitize(st):
 	st = str(st)
-	st = re.sub("^\['",'',st)
-	st = re.sub('^\["','',st)
-	st = re.sub("'\]$",'',st)
-	st = re.sub('"\]$','',st)
-	st = re.sub("^\s+",'',st)
-	st = re.sub("\s+$",'',st)
+	st = re.sub(r"^\['",'',st)
+	st = re.sub(r'^\["','',st)
+	st = re.sub(r"'\]$",'',st)
+	st = re.sub(r'"\]$','',st)
+	st = re.sub(r"^\s+",'',st)
+	st = re.sub(r"\s+$",'',st)
 	return st
 
 #Clean up filenames
 def fsanitize(st):
-	st = re.sub('[^a-zA-Z0-9 \-_.,]','',st)
-	st = re.sub('\s+$','',st)
-	st = re.sub('^\s+','',st)
+	st = re.sub(r'[^a-zA-Z0-9 \-_.,]','',st)
+	st = re.sub(r'\s+$','',st)
+	st = re.sub(r'^\s+','',st)
 	return st
 
 def scan():


### PR DESCRIPTION
Hello

I found `siPhon` this evening when trying to copy music from an ancient iPod. Great tool, thanks for writing it.

When running `siPhon` with `python` version `3.13.2` I got a few warnings because of the regex format:
```
/home/user/siPhon/siPhon:117: SyntaxWarning: invalid escape sequence '\['
  st = re.sub("^\['",'',st)
/home/user/siPhon/siPhon:118: SyntaxWarning: invalid escape sequence '\['
  st = re.sub('^\["','',st)
/home/user/siPhon/siPhon:119: SyntaxWarning: invalid escape sequence '\]'
  st = re.sub("'\]$",'',st)
/home/user/siPhon/siPhon:120: SyntaxWarning: invalid escape sequence '\]'
  st = re.sub('"\]$','',st)
/home/user/siPhon/siPhon:121: SyntaxWarning: invalid escape sequence '\s'
  st = re.sub("^\s+",'',st)
/home/user/siPhon/siPhon:122: SyntaxWarning: invalid escape sequence '\s'
  st = re.sub("\s+$",'',st)
/home/user/siPhon/siPhon:127: SyntaxWarning: invalid escape sequence '\-'
  st = re.sub('[^a-zA-Z0-9 \-_.,]','',st)
/home/user/siPhon/siPhon:128: SyntaxWarning: invalid escape sequence '\s'
  st = re.sub('\s+$','',st)
/home/user/siPhon/siPhon:129: SyntaxWarning: invalid escape sequence '\s'
  st = re.sub('^\s+','',st)
```
I've made the patterns into raw strings. 

I also added the `conda` recipe I used to create an environment with `siPhon`'s dependencies. These are opinionated changes, feel free to reject them; I just wanted to push something back because you solved a problem for me. Thanks agian.